### PR TITLE
support for flask-sqlalchemy >= 3.1.0

### DIFF
--- a/src/flask_alembic/extension.py
+++ b/src/flask_alembic/extension.py
@@ -1,3 +1,4 @@
+import importlib
 import logging
 import os
 import shutil
@@ -519,7 +520,10 @@ class Alembic:
 
     @property
     def flask_sqlalchemy_db(self):
-        ext_version = tuple(int(_) for _ in flask_sqlalchemy.__version__.split(".")[:3])
+        ext_version = tuple(
+            int(_)
+            for _ in importlib.metadata.version("flask-sqlalchemy").split(".")[:3]
+        )
 
         if ext_version >= (3, 1, 0):
             return current_app.extensions["sqlalchemy"]


### PR DESCRIPTION
`Flask-SQLAlchemy v3.1.0` removes `current_app.extensions["sqlalchemy"].db` attribute.

https://github.com/pallets-eco/flask-sqlalchemy/pull/1113