### PR TITLE
fix relative ids for downgrade/upgrade

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 Unlreleased
 
+- Fix handling of relative ids (`+1`, `-1`) passed to `downgrade` and `upgrade`.
+
 ## Version 3.0.0
 
 Released 2024-02-08


### PR DESCRIPTION
Unlike `upgrade`, the internals of Alembic's `downgrade` only accept a single id, never a list. Meanwhile, Alembic's internal `upgrade` does accept a list despite its signature, but when passing a relative id (`+1`) it must be a single id, and it must start with `+`.